### PR TITLE
Push QMAPI to AWS Registry

### DIFF
--- a/.scripts/deploy.sh
+++ b/.scripts/deploy.sh
@@ -1,0 +1,7 @@
+#!/usr/bin/env bash
+
+$(aws ecr get-login --no-include-email --region eu-west-1)
+docker build -t 178402416679.dkr.ecr.eu-west-1.amazonaws.com/queuemetrics-api:${CI_COMMIT_HASH} .
+docker tag 178402416679.dkr.ecr.eu-west-1.amazonaws.com/queuemetrics-api:${CI_COMMIT_HASH} 178402416679.dkr.ecr.eu-west-1.amazonaws.com/queuemetrics-api:latest
+docker push 178402416679.dkr.ecr.eu-west-1.amazonaws.com/queuemetrics-api:${CI_COMMIT_HASH}
+docker push 178402416679.dkr.ecr.eu-west-1.amazonaws.com/queuemetrics-api:latest

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,0 +1,10 @@
+FROM node:10-alpine
+
+RUN apk update && apk upgrade
+
+COPY src /src
+COPY node_modules /src/node_modules
+COPY package.json /src/package.json
+
+EXPOSE 8765
+CMD node /src/server.js

--- a/package.json
+++ b/package.json
@@ -1,10 +1,15 @@
 {
   "name": "queuemetrics-api",
+  "platform": "custom",
+  "owner": "telephony",
+  "ci": "dockyard",
   "version": "1.0.0",
   "description": "An API for reaching the queuemetrics database",
   "main": "server.js",
   "scripts": {
-    "test": "echo \"Error: no test specified\" && exit 1"
+    "test": "echo \"No test specified\"",
+    "ci": "echo \"No CI to perfrom\"",
+    "deploy": "/bin/bash ./.scripts/deploy.sh"
   },
   "repository": {
     "type": "git",


### PR DESCRIPTION
This PR will build a docker image and push it to the AWS registry.  Chiffer will then come along and grab that image later down the line.